### PR TITLE
Loop in preference order first, font order second

### DIFF
--- a/autoload/simple_guifont.vim
+++ b/autoload/simple_guifont.vim
@@ -29,8 +29,8 @@ function! s:GtkGetSystemFonts()
 endfunction
 
 function! s:GtkFindBestFont(system_fonts, preferred_fonts, fallback_font)
-  for system_font in a:system_fonts
-    for preferred_font in a:preferred_fonts
+  for preferred_font in a:preferred_fonts
+    for system_font in a:system_fonts
       if preferred_font ==? system_font
         return preferred_font
       endif


### PR DESCRIPTION
Hey there, thanks for writing the plugin. Makes my cross-platform Vim use a bit easier.

I did notice one issue: It's not clear from the README whether it's _supposed_ to be, but my initial understanding of the "preferred fonts" list was that it's in order of my font preference. As is, since the outer loop is through the system fonts, I end up getting whichever font in my preferred list (that is on the system) comes alphabetically first.

This PR just swaps the two loops so we look through the list of system fonts for the first preference, then the second preference, etc.